### PR TITLE
Fix `searchUsers` for tupper

### DIFF
--- a/tests/users.ts
+++ b/tests/users.ts
@@ -29,7 +29,17 @@ test(
 	(t) => {
 		const { context } = t;
 
-		t.assert(context.body.contains(tupperUserId), "Should contain Tupper");
+		//Todo: a `filter`, `map`, `for in` or `some` on `context.body` makes the test freeze completely
+		//		Thus we do a regular for loop here.
+		let foundTupper = false;
+		for(let i = 0; i < context.body.length; i++){
+			if (context.body[i].id === tupperUserId) {
+				foundTupper = true;
+				break;
+			}
+		}
+
+		t.is(foundTupper, true, "Should contain Tupper");
 	}
 );
 


### PR DESCRIPTION
I was in the process of making a few more fixes to the tests, but now the `ava` test command just freezes.

After waiting a bit I can run tests as usual again. It's probably just that the api limited me.