### PR TITLE
Add tests for update group representation endpoint

### DIFF
--- a/tests/_consts.ts
+++ b/tests/_consts.ts
@@ -30,3 +30,4 @@ export const tupperUserId = "usr_c1644b5b-3ca4-45b4-97c6-a2a0de70d469";
 export const defaultAvatarId = "avtr_c38a1615-5bf5-42b4-84eb-a8b6c37cbd11";
 export const vrchatHomeWorldId = "wrld_4432ea9b-729c-46e3-8eaf-846aa0a37fdd";
 export const favoriteId = "fvrt_6d1580a7-2670-414b-b197-d4adea72467a";
+export const vrcWikiTeamGroupId = "grp_0f1d4450-822e-45d5-b5aa-6a0ea8402053";

--- a/tests/groups.ts
+++ b/tests/groups.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { failUnauthenticated, test, testOperation } from "./_utilities.js";
 import { state, unstableValues } from "./_cache.js";
-import { vrchatFriendId } from "./_consts.js";
+import { vrchatFriendId, vrcWikiTeamGroupId } from "./_consts.js";
 
 const unstableGroupKeys = [
 	"id",
@@ -140,6 +140,42 @@ test.serial(
 		});
 	}
 );
+
+test.serial(testOperation, "updateGroupRepresentation", () => ({
+	parameters: {
+		groupId: state.get("groupId"),
+	},
+	requestBody: {
+		isRepresenting: true,
+	},
+	statusCode: 200,
+}));
+
+test.serial(
+	"with group user is not a member of",
+	testOperation,
+	"updateGroupRepresentation",
+	{
+		parameters: {
+			groupId: vrcWikiTeamGroupId,
+		},
+		requestBody: {
+			isRepresenting: false,
+		},
+		statusCode: 403,
+	}
+);
+
+test.serial("with invalid group", testOperation, "updateGroupRepresentation", {
+	parameters: {
+		groupId: "grp_00000000-0000-0000-0000-000000000000",
+	},
+	requestBody: {
+		isRepresenting: false,
+	},
+	statusCode: 403,
+});
+
 
 test.serial(testOperation, "deleteGroupInvite", () => ({
 	parameters: {


### PR DESCRIPTION
Adds tests for the new endpoint defined in https://github.com/vrchatapi/specification/pull/470. 

As my test account doesn't have VRC+, I've not ran these tests as provided. I did however run them successfully by overriding the groupId on the state (not included in this PR). 